### PR TITLE
JWT 연동 및 Flask 서버 연동

### DIFF
--- a/Osori/build.gradle
+++ b/Osori/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/Osori/build.gradle
+++ b/Osori/build.gradle
@@ -30,6 +30,11 @@ dependencies {
 	implementation group: 'com.google.apis', name: 'google-api-services-youtube', version: 'v3-rev222-1.25.0'
 	implementation group: 'com.google.oauth-client', name: 'google-oauth-client-jetty', version: '1.31.5'
 
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation group: 'io.jsonwebtoken', name:'jjwt-impl', version:'0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
 }
 
 tasks.named('test') {

--- a/Osori/src/main/java/com/Osori/config/JwtSecurityConfig.java
+++ b/Osori/src/main/java/com/Osori/config/JwtSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.Osori.config;
+
+import com.Osori.jwt.JwtFilter;
+import com.Osori.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/Osori/src/main/java/com/Osori/config/SecurityConfig.java
+++ b/Osori/src/main/java/com/Osori/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package com.Osori.config;
+
+import com.Osori.jwt.JwtAccessDeniedHandler;
+import com.Osori.jwt.JwtAuthenticationEntryPoint;
+import com.Osori.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final TokenProvider tokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http.csrf().disable()
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                .and()
+                .authorizeRequests()
+                .antMatchers("/signup","/signin").permitAll()
+                .anyRequest().authenticated()
+
+                .and()
+                .apply(new JwtSecurityConfig(tokenProvider));
+
+        http.cors();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns((Arrays.asList("*")));
+        configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/Osori/src/main/java/com/Osori/controller/ChatController.java
+++ b/Osori/src/main/java/com/Osori/controller/ChatController.java
@@ -11,17 +11,17 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/chat/{userId}")
+@RequestMapping("/chat")
 public class ChatController {
     private final ChatService chatService;
 
     @GetMapping
-    public ResponseEntity<ChatResDto> getChats(@PathVariable("userId") Long userId){
-        return new ResponseEntity<>(chatService.getChats(userId), HttpStatus.OK);
+    public ResponseEntity<ChatResDto> getChats(@RequestHeader(value = "Authorization") String userToken){
+        return new ResponseEntity<>(chatService.getChats(userToken), HttpStatus.OK);
     }
 
     @PostMapping
-    public ResponseEntity<AnswerResDto> sendChat(@PathVariable("userId") Long userId, @RequestBody AnswerReqDto answerReqDto){
-        return new ResponseEntity<>(chatService.createAnswer(userId, answerReqDto), HttpStatus.OK);
+    public ResponseEntity<AnswerResDto> sendChat(@RequestHeader(value = "Authorization") String userToken, @RequestBody AnswerReqDto answerReqDto){
+        return new ResponseEntity<>(chatService.createAnswer(userToken, answerReqDto), HttpStatus.OK);
     }
 }

--- a/Osori/src/main/java/com/Osori/controller/PlaylistController.java
+++ b/Osori/src/main/java/com/Osori/controller/PlaylistController.java
@@ -12,29 +12,29 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/playlist/{userId}")
+@RequestMapping("/playlist")
 public class PlaylistController {
     private final PlaylistService playlistService;
 
     @GetMapping
-    public ResponseEntity<PlaylistResDto> getPlaylist(@PathVariable("userId") Long userId){
-        return new ResponseEntity<>(playlistService.getPlaylist(userId), HttpStatus.OK);
+    public ResponseEntity<PlaylistResDto> getPlaylist(@RequestHeader(value = "Authorization") String userToken){
+        return new ResponseEntity<>(playlistService.getPlaylist(userToken), HttpStatus.OK);
     }
 
     @PostMapping
-    public ResponseEntity<Void> addPlaylist(@PathVariable("userId") Long userId, @RequestBody PlaylistReqDto playlistReqDto){
-        playlistService.addPlaylist(userId, playlistReqDto);
+    public ResponseEntity<Void> addPlaylist(@RequestHeader(value = "Authorization") String userToken, @RequestBody PlaylistReqDto playlistReqDto){
+        playlistService.addPlaylist(userToken, playlistReqDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePlaylist(@PathVariable("userId") Long userId, @PathVariable("id") Long playlistId){
-        playlistService.deletePlaylist(userId, playlistId);
+    public ResponseEntity<Void> deletePlaylist(@RequestHeader(value = "Authorization") String userToken, @PathVariable("id") Long playlistId){
+        playlistService.deletePlaylist(userToken, playlistId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<DetailResDto> detailPlaylist(@PathVariable("userId") Long userId, @PathVariable("id") Long playlistId){
-        return new ResponseEntity<>(playlistService.detailPlaylist(userId, playlistId), HttpStatus.OK);
+    public ResponseEntity<DetailResDto> detailPlaylist(@RequestHeader(value = "Authorization") String userToken, @PathVariable("id") Long playlistId){
+        return new ResponseEntity<>(playlistService.detailPlaylist(userToken, playlistId), HttpStatus.OK);
     }
 }

--- a/Osori/src/main/java/com/Osori/dto/QueryDto.java
+++ b/Osori/src/main/java/com/Osori/dto/QueryDto.java
@@ -1,0 +1,14 @@
+package com.Osori.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QueryDto {
+    private List<String> playlist;
+}

--- a/Osori/src/main/java/com/Osori/dto/TokenDto.java
+++ b/Osori/src/main/java/com/Osori/dto/TokenDto.java
@@ -1,0 +1,14 @@
+package com.Osori.dto;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+    private String grantType;
+    private String accessToken;
+    private Long accessTokenExpiresIn;
+}

--- a/Osori/src/main/java/com/Osori/dto/UserResDto.java
+++ b/Osori/src/main/java/com/Osori/dto/UserResDto.java
@@ -11,11 +11,13 @@ import lombok.*;
 public class UserResDto {
     private Long id;
     private String nickname;
+    private TokenDto token;
 
-    public static UserResDto of(User user){
+    public static UserResDto of(User user, TokenDto token){
         return UserResDto.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())
+                .token(token)
                 .build();
     }
 }

--- a/Osori/src/main/java/com/Osori/exception/ErrorCode.java
+++ b/Osori/src/main/java/com/Osori/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     NOT_EXIST_PLAYLIST(HttpStatus.NOT_FOUND, "존재하지 않는 플레이리스트 입니다."),
     MISMATCH_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀립니다."),
     PERMISSION_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드 입니다."), //405
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류 입니다."); // 500
 

--- a/Osori/src/main/java/com/Osori/exception/ExceptionController.java
+++ b/Osori/src/main/java/com/Osori/exception/ExceptionController.java
@@ -5,6 +5,8 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.io.IOException;
+
 @RestControllerAdvice
 public class ExceptionController {
     @ExceptionHandler(CustomException.class)
@@ -27,6 +29,13 @@ public class ExceptionController {
     protected ResponseEntity<ErrorResponse> handleException(final Exception e){
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(IOException.class)
+    protected ResponseEntity<ErrorResponse> handleIOException(final Exception e){
+        return ResponseEntity
+                .status(ErrorCode.NOT_EXIST_TOKEN.getStatus().value())
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/Osori/src/main/java/com/Osori/jwt/JwtAccessDeniedHandler.java
+++ b/Osori/src/main/java/com/Osori/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package com.Osori.jwt;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/Osori/src/main/java/com/Osori/jwt/JwtAuthenticationEntryPoint.java
+++ b/Osori/src/main/java/com/Osori/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.Osori.jwt;
+
+import com.Osori.exception.CustomException;
+import com.Osori.exception.ErrorCode;
+import com.Osori.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint{
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        PrintWriter writer = response.getWriter();
+        writer.println("{ " + "\"timestamp\" : \"" + LocalDateTime.now()
+                + "\", \"status\" : \"" +  ErrorCode.NOT_EXIST_TOKEN.getStatus().value()
+                + "\", \"error\" : \"" + ErrorCode.NOT_EXIST_TOKEN.getStatus().name()
+                + "\", \"code\" : \"" + ErrorCode.NOT_EXIST_TOKEN.name()
+                + "\", \"message\" : \"" + ErrorCode.NOT_EXIST_TOKEN.getMessage()
+                + "\"}");
+    }
+}

--- a/Osori/src/main/java/com/Osori/jwt/JwtFilter.java
+++ b/Osori/src/main/java/com/Osori/jwt/JwtFilter.java
@@ -1,0 +1,44 @@
+package com.Osori.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String jwt = resolveToken(request);
+
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            String userEmail = tokenProvider.getUserEmailFromToken(jwt);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userEmail,null,null);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/Osori/src/main/java/com/Osori/jwt/SecurityUtil.java
+++ b/Osori/src/main/java/com/Osori/jwt/SecurityUtil.java
@@ -1,0 +1,17 @@
+package com.Osori.jwt;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+    private SecurityUtil() { }
+
+    public static String getCurrentUserEmail() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw  new RuntimeException("Security Context 에 인증 정보가 없습니다.");
+        }
+
+        return authentication.getName();
+    }
+}

--- a/Osori/src/main/java/com/Osori/jwt/TokenProvider.java
+++ b/Osori/src/main/java/com/Osori/jwt/TokenProvider.java
@@ -1,0 +1,75 @@
+package com.Osori.jwt;
+
+
+import com.Osori.dto.TokenDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class TokenProvider {
+    private static final String BEARER_TYPE = "bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
+
+    private final Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secretKey){
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenDto generateTokenDto(Authentication authentication){
+        Date accessTokenExpiresIn = new Date((new Date()).getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .build();
+    }
+
+    //복호화
+    public String getUserEmailFromToken(String accessToken){ // type
+        Claims claims = parseClaims(accessToken);
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+
+    public Claims parseClaims(String accessToken){
+        try{
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        }catch (ExpiredJwtException ex){
+            System.out.println("여기가 맞나?");
+            return ex.getClaims();
+        }
+    }
+}

--- a/Osori/src/main/java/com/Osori/service/ChatService.java
+++ b/Osori/src/main/java/com/Osori/service/ChatService.java
@@ -7,6 +7,7 @@ import com.Osori.domain.repository.UserRepository;
 import com.Osori.dto.*;
 import com.Osori.exception.CustomException;
 import com.Osori.exception.ErrorCode;
+import com.Osori.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,22 +19,25 @@ import java.util.List;
 public class ChatService {
     private final UserRepository userRepository;
     private final ChatRepository chatRepository;
+    private final TokenProvider tokenProvider;
 
     private final YoutubeService youtubeService;
 
-    private User getUser(Long userId){
-        return userRepository.findById(userId)
+    private User getUser(String userToken){
+        String userToken_ = userToken.substring(7);
+        String userEmail = tokenProvider.getUserEmailFromToken(userToken_);
+        return userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_USER));
     }
 
-    public ChatResDto getChats(Long userId){
-        User user = getUser(userId);
+    public ChatResDto getChats(String userToken){
+        User user = getUser(userToken);
         List<Chat> chatList = chatRepository.findByUser(user);
         return ChatResDto.of(chatList);
     }
 
-    public AnswerResDto createAnswer(Long userId, AnswerReqDto answerReqDto){
-        User user = getUser(userId);
+    public AnswerResDto createAnswer(String userToken, AnswerReqDto answerReqDto){
+        User user = getUser(userToken);
 
         List<YoutubeDto> playlists = new ArrayList<>();
         String answer = answerReqDto.getContent() + "에 대한 대답";

--- a/Osori/src/main/java/com/Osori/service/PlaylistService.java
+++ b/Osori/src/main/java/com/Osori/service/PlaylistService.java
@@ -12,6 +12,7 @@ import com.Osori.dto.PlaylistReqDto;
 import com.Osori.dto.PlaylistResDto;
 import com.Osori.exception.CustomException;
 import com.Osori.exception.ErrorCode;
+import com.Osori.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,26 +25,29 @@ public class PlaylistService {
     private final PlaylistRepository playlistRepository;
     private final MusicRepository musicRepository;
     private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
 
-    private User getUser(Long userId){
-        return userRepository.findById(userId)
+    private User getUser(String userToken){
+        String userToken_ = userToken.substring(7);
+        String userEmail = tokenProvider.getUserEmailFromToken(userToken_);
+        return userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_USER));
     }
 
-    private Playlist checkAuth(Long userId, Long playlistId){
-        User user = getUser(userId);
+    private Playlist checkAuth(String userToken, Long playlistId){
+        User user = getUser(userToken);
         return playlistRepository.findByIdAndUser(playlistId, user)
                 .orElseThrow(() -> new CustomException(ErrorCode.PERMISSION_NOT_ALLOWED));
     }
 
-    public PlaylistResDto getPlaylist(Long userId){
-        User user = getUser(userId);
+    public PlaylistResDto getPlaylist(String userToken){
+        User user = getUser(userToken);
         List<Playlist> playlists = playlistRepository.findByUser(user);
         return PlaylistResDto.of(playlists);
     }
 
-    public void addPlaylist(Long userId, PlaylistReqDto playlistReqDto){
-        User user = getUser(userId);
+    public void addPlaylist(String userToken, PlaylistReqDto playlistReqDto){
+        User user = getUser(userToken);
         Playlist playlist = playlistRepository.save(Playlist.builder()
                 .name(playlistReqDto.getName())
                 .thumbnail(playlistReqDto.getMusics().get(0).getThumbnail())
@@ -63,13 +67,13 @@ public class PlaylistService {
         musicRepository.saveAll(musicList);
     }
 
-    public void deletePlaylist(Long userId, Long playlistId){
-        Playlist playlist = checkAuth(userId, playlistId);
+    public void deletePlaylist(String userToken, Long playlistId){
+        Playlist playlist = checkAuth(userToken, playlistId);
         playlistRepository.delete(playlist);
     }
 
-    public DetailResDto detailPlaylist(Long userId, Long playlistId){
-        Playlist playlist = checkAuth(userId, playlistId);
+    public DetailResDto detailPlaylist(String userToken, Long playlistId){
+        Playlist playlist = checkAuth(userToken, playlistId);
         return DetailResDto.of(playlist);
     }
 }

--- a/Osori/src/main/java/com/Osori/service/SigninService.java
+++ b/Osori/src/main/java/com/Osori/service/SigninService.java
@@ -3,16 +3,21 @@ package com.Osori.service;
 import com.Osori.domain.entity.User;
 import com.Osori.domain.repository.UserRepository;
 import com.Osori.dto.SigninReqDto;
+import com.Osori.dto.TokenDto;
 import com.Osori.dto.UserResDto;
 import com.Osori.exception.CustomException;
 import com.Osori.exception.ErrorCode;
+import com.Osori.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class SigninService {
     private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
 
     private UserResDto checkUser(SigninReqDto signinReqDto){
         User user = userRepository.findByEmail(signinReqDto.getEmail())
@@ -22,7 +27,9 @@ public class SigninService {
             throw new CustomException(ErrorCode.MISMATCH_PASSWORD);
         }
 
-        return UserResDto.of(user);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getEmail(),"",null);
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+        return UserResDto.of(user, tokenDto);
     }
 
     public UserResDto Login(SigninReqDto signinReqDto){

--- a/Osori/src/main/resources/application.properties
+++ b/Osori/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.naming.physical-strategy = org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.profiles.include[0]=db
 spring.profiles.include[1]=youtube
+spring.profiles.include[2]=jwt

--- a/Osori/src/main/resources/application.properties
+++ b/Osori/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.jpa.hibernate.naming.physical-strategy = org.hibernate.boot.model.naming.
 spring.profiles.include[0]=db
 spring.profiles.include[1]=youtube
 spring.profiles.include[2]=jwt
+spring.profiles.include[3]=flask


### PR DESCRIPTION
JWT를 사용한 사용자 관리
- 첫 로그인 시 JWT 토큰 발급
- 이후 활동들에 헤더에 발급된 토큰을 첨가하여 요청
- 토큰에서 사용자 추출 및 권한 확인

Flask 서버와 연동
- 채팅 입력 시 그대로 flask 서버로 요청
- flask에서는 키워드 추출 및 해당 키워드와 유사한 태그들 추출, 음원 추출 및 반환
- 추출된 음악 리스트 반환
- 존재하지 않으면 재 요청
